### PR TITLE
Simulator goroutine refactor

### DIFF
--- a/cmd/main/basicSystem/basicSystem_test.go
+++ b/cmd/main/basicSystem/basicSystem_test.go
@@ -20,8 +20,8 @@ func TestBasicSystem(t *testing.T) {
 		[]float64{0.0, 0.0, 0.0, 0.2, 0.2, 0.2, 0.2, 0.2},
 		0,
 		math.Pow10(-6))
-	manager.SimulateManyGenerations(100, 1)
 	manager := manager.NewManager(&targetSystem, 100, 8, geneticBreeder, false)
+	manager.SimulateManyGenerations(100)
 
 	os.RemoveAll("data")
 	os.RemoveAll("logs")

--- a/cmd/main/basicSystem/basicSystem_test.go
+++ b/cmd/main/basicSystem/basicSystem_test.go
@@ -20,8 +20,8 @@ func TestBasicSystem(t *testing.T) {
 		[]float64{0.0, 0.0, 0.0, 0.2, 0.2, 0.2, 0.2, 0.2},
 		0,
 		math.Pow10(-6))
-	manager := manager.NewManager(&targetSystem, 100, geneticBreeder, false)
 	manager.SimulateManyGenerations(100, 1)
+	manager := manager.NewManager(&targetSystem, 100, 8, geneticBreeder, false)
 
 	os.RemoveAll("data")
 	os.RemoveAll("logs")

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -20,7 +20,7 @@ func main() {
 		[]float64{0.0, 1.0},
 		1,
 		math.Pow10(-6))
-	manager.SimulateManyGenerations(50, 10)
 	manager := manager.NewManager(targetSystem, 100, 16, geneticBreeder, true)
+	manager.SimulateManyGenerations(50)
 	manager.WriteStop()
 }

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -20,7 +20,7 @@ func main() {
 		[]float64{0.0, 1.0},
 		1,
 		math.Pow10(-6))
-	manager := manager.NewManager(targetSystem, 1000, geneticBreeder, true)
 	manager.SimulateManyGenerations(50, 10)
+	manager := manager.NewManager(targetSystem, 100, 16, geneticBreeder, true)
 	manager.WriteStop()
 }

--- a/cmd/main/multiAgentSystem/multiAgentSystem_test.go
+++ b/cmd/main/multiAgentSystem/multiAgentSystem_test.go
@@ -20,8 +20,8 @@ func TestMultiAgentSystem(t *testing.T) {
 		[]float64{0.0, 0.0, 0.0, 0.2, 0.2, 0.2, 0.2, 0.2},
 		2,
 		math.Pow10(-6))
-	manager := manager.NewManager(&targetSystem, 100, geneticBreeder, false)
 	manager.SimulateManyGenerations(100, 1)
+	manager := manager.NewManager(&targetSystem, 10, 8, geneticBreeder, false)
 
 	os.RemoveAll("data")
 	os.RemoveAll("logs")

--- a/cmd/main/multiAgentSystem/multiAgentSystem_test.go
+++ b/cmd/main/multiAgentSystem/multiAgentSystem_test.go
@@ -20,8 +20,8 @@ func TestMultiAgentSystem(t *testing.T) {
 		[]float64{0.0, 0.0, 0.0, 0.2, 0.2, 0.2, 0.2, 0.2},
 		2,
 		math.Pow10(-6))
-	manager.SimulateManyGenerations(100, 1)
 	manager := manager.NewManager(&targetSystem, 10, 8, geneticBreeder, false)
+	manager.SimulateManyGenerations(100)
 
 	os.RemoveAll("data")
 	os.RemoveAll("logs")

--- a/pkg/Manager/Manager.go
+++ b/pkg/Manager/Manager.go
@@ -90,54 +90,83 @@ func NewManager(system system.System, numSimulationsPerGeneration int, numThread
 	}
 }
 
+// Simulate a single repetition, of which there may be many (always at least one) within a generation
+// This method is not exposed publicly. The intention is for users to call SimulateGeneration instead.
+func (manager *Manager) simulateRepetition() error {
+	numAgentsPerSimulation := manager.system.NumAgentsPerSimulation()
+
+	// Channel to send collections of agents through to simulation goroutines.
+	// The number of agents sent at once is equal to the number of agents required
+	// for one simulation.
+	agentChannel := make(chan []*agent.Agent, manager.numSimulationsPerGeneration)
+	// Channel to receive signals (hence generic struct{}) for when a simulation finishes.
+	simulationFinishedSignalChannel := make(chan struct{})
+	// A simple counter of how many simulations are running
+	simulationsRunningCounter := 0
+
+	// Create a number of goroutines to handle as simulations
+	for i := 0; i < manager.numThreads; i++ {
+		go simulator.ConcurrentSimulationRoutine(manager.system, agentChannel, simulationFinishedSignalChannel)
+	}
+
+	// Shuffle the agents (to avoid bias)
+	utils.ShuffleSlice(manager.randomGenerator, manager.currentGeneration)
+
+	// Actually start all the simulations
+	for simulationIndex := 0; simulationIndex < manager.numSimulationsPerGeneration; simulationIndex++ {
+		simulationsRunningCounter += 1
+		// Find the agents to be used in this simulation
+		simulationAgents := manager.currentGeneration[numAgentsPerSimulation*simulationIndex : numAgentsPerSimulation*(simulationIndex+1)]
+		// Send the agents to the simulators - blocks until agents can be taken
+		agentChannel <- simulationAgents
+	}
+	close(agentChannel)
+
+	// Count any finished simulations and decrement the simulation counter
+	for range simulationFinishedSignalChannel {
+		simulationsRunningCounter -= 1
+		if simulationsRunningCounter <= 0 {
+			break
+		}
+	}
+
+	return nil
+}
+
 // Simulate a single generation of the system, updating the data writers and breeding the next generation
 //
-// simulationPerGeneration defines how many simulations to run before tallying up the agents
-// scores and breeding a new generation. A large number is better, as it averages agent
-// performance.
-func (manager *Manager) SimulateGeneration(simulationsPerGeneration int) error {
+// simulationPerGeneration
+func (manager *Manager) SimulateGeneration() error {
 	defer func() { manager.generationIndex += 1 }()
 	sigintChannel := make(chan os.Signal, 1)
 	signal.Notify(sigintChannel, os.Interrupt)
 
 	manager.logger.Printf("STARTING SIMULATION OF GENERATION %v\n", manager.generationIndex)
-	numAgentsPerSimulation := manager.system.NumAgentsPerSimulation()
-
-	// Keep a waitgroup to keep track of how many simulations have finished
-	var simulationWaitGroup sync.WaitGroup
 
 	// Use a progressbar to track how far through the simulations we are.
 	// If we are only doing a single generation, use a silent progress bar instead
-	var simulationProgressBar *progressbar.ProgressBar
-	if simulationsPerGeneration > 1 {
-		simulationProgressBar = progressbar.Default(int64(simulationsPerGeneration), "SIMULATIONS")
+	var simulationRepeatsProgressBar *progressbar.ProgressBar
+	if manager.numSimulationsPerGeneration > 1 {
+		simulationRepeatsProgressBar = progressbar.Default(int64(manager.numSimulationsPerGeneration), "SIMULATION REPETITIONS")
 	} else {
-		simulationProgressBar = progressbar.DefaultSilent(int64(simulationsPerGeneration))
+		simulationRepeatsProgressBar = progressbar.DefaultSilent(int64(manager.numSimulationsPerGeneration))
 	}
 
-	// Simulate potentially many times
-	for simulationIndex := 0; simulationIndex < simulationsPerGeneration; simulationIndex++ {
+	// Simulate as many times as required, passing agents through channel to awaiting goroutines
+	for simulationRepeatIndex := 0; simulationRepeatIndex < manager.numSimulationsPerGeneration; simulationRepeatIndex++ {
+		// Handle any keyboard interrupts
 		select {
 		case <-sigintChannel:
 			manager.logger.Println("GOT KEYBOARD INTERRUPT")
 			return errors.New("got keyboard interrupt")
 		default:
 		}
-		// Shuffle the agents (to avoid bias)
-		utils.ShuffleSlice(manager.randomGenerator, manager.currentGeneration)
-		// Actually start all the simulations
-		for simulationIndex := 0; simulationIndex < manager.numSimulationsPerGeneration; simulationIndex++ {
-			simulationWaitGroup.Add(1)
-			// Find the agents to be used in this simulation
-			simulationAgents := manager.currentGeneration[numAgentsPerSimulation*simulationIndex : numAgentsPerSimulation*(simulationIndex+1)]
-			// Start simulation in very simple anonymous wrapper - to decrement waitgroup when simulation is done
-			go func() {
-				defer simulationWaitGroup.Done()
-				simulator.SimulateSystem(manager.system, simulationAgents)
-			}()
+
+		err := manager.simulateRepetition()
+		if err != nil {
+			return err
 		}
-		simulationWaitGroup.Wait()
-		simulationProgressBar.Add(1)
+		simulationRepeatsProgressBar.Add(1)
 	}
 	manager.logger.Println("FINISHED SIMULATING GENERATION")
 
@@ -170,11 +199,11 @@ func (manager *Manager) SimulateGeneration(simulationsPerGeneration int) error {
 	return nil
 }
 
-// Simulate many generations at once, with handling for SIGINT
-func (manager *Manager) SimulateManyGenerations(numGenerations int, simulationsPerGeneration int) {
+// Simulate many generations in a loop
+func (manager *Manager) SimulateManyGenerations(numGenerations int) {
 	var err error
 	for generationIndex := 0; generationIndex < numGenerations; generationIndex++ {
-		err = manager.SimulateGeneration(simulationsPerGeneration)
+		err = manager.SimulateGeneration()
 		if err != nil {
 			break
 		}


### PR DESCRIPTION
Update the simulator to use a collection of worker pool threads for simulations, rather than one thread per simulation. This appears to improve performance for larger number of simulations.

Closes #72 